### PR TITLE
Fix: Remove invalid 'react-dom/client' from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@google/genai": "^1.6.0",
     "react": "^19.1.0",
-    "react-dom/client": "^19.1.0",
     "react-dom": "^19.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The package 'react-dom/client' is not a valid npm package name and was causing the build to fail. 'react-dom/client' is an import path used with React 18+ for the new root API.

This commit removes the incorrect entry from package.json. The correct 'react-dom' dependency was already present.